### PR TITLE
[ADD]当日の使用金額確認ページ作成

### DIFF
--- a/lib/check_daily_using.dart
+++ b/lib/check_daily_using.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+//一日に使える金額を事前に決めて円グラフでどれぐらいに達しているかを見れたりするとええな
+class CheckDailyUsing extends StatelessWidget {
+  //フォームの入力をイニシャライザ（多分コンストラクタ的なもの）で取得
+  CheckDailyUsing(this.value);
+  final value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('当日の使用金額確認ページ'),
+      ),
+      body: Center(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            '本日の使用金額',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 40),
+          ),
+          //データベースからその日の使用金額を取得し、フォームからの入力情報に加算
+          Text(
+            value,
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 30),
+          )
+        ],
+      )),
+    );
+  }
+}

--- a/lib/input_pay.dart
+++ b/lib/input_pay.dart
@@ -1,7 +1,11 @@
+import 'package:daypay/check_monthly_using.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'check_daily_using.dart';
 
 class InputPay extends StatelessWidget {
+  final valueController = TextEditingController();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -17,6 +21,7 @@ class InputPay extends StatelessWidget {
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 30),
             ),
             TextField(
+              controller: valueController,
               keyboardType: TextInputType.number,
               inputFormatters: <TextInputFormatter>[
                 FilteringTextInputFormatter.digitsOnly // ③ 数字入力のみ許可する
@@ -24,16 +29,34 @@ class InputPay extends StatelessWidget {
               autofocus: true,
             ),
             ElevatedButton(
-              child: const Text('今日使った金額へ'),
+              child: const Text('今日使った金額へ遷移する'),
               style: ElevatedButton.styleFrom(
                 padding: EdgeInsets.all(15),
                 primary: Colors.orange,
                 onPrimary: Colors.white,
               ),
               onPressed: () {
-                print('今日使った金額へ遷移');
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) =>
+                            CheckDailyUsing(valueController.text)));
               },
             ),
+            ElevatedButton(
+              child: Text('カレンダーへ'),
+              style: ElevatedButton.styleFrom(
+                padding: EdgeInsets.all(15),
+                primary: Colors.teal,
+                onPrimary: Colors.white,
+              ),
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => CheckMonthlyUsing()));
+              },
+            )
           ],
         ),
       ),

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'check_monthly_using.dart';
 import 'input_pay.dart';
 
 class Test extends StatelessWidget {
@@ -8,15 +9,14 @@ class Test extends StatelessWidget {
       body: Center(
         child: RaisedButton(
           child: Text('次へ'),
-          onPressed: (){
+          onPressed: () {
             // 押したら反応するコードを書く
             // 画面遷移のコード
             Navigator.push(
                 context,
                 MaterialPageRoute(
                   builder: (context) => InputPay(),
-                )
-            );
+                ));
           },
         ),
       ),


### PR DESCRIPTION
使用金額入力後に遷移するページ（「当日の利用金額合計」画面を作成）。
とりあえず入力金額をそのまま表示する処理にしていますが、バックでDBから当日のデータを取得して合計を算出する必要がある。