### PR TITLE
[ADD]Firebaseへの登録処理追加

### DIFF
--- a/lib/input_pay.dart
+++ b/lib/input_pay.dart
@@ -1,4 +1,5 @@
 import 'package:daypay/check_monthly_using.dart';
+import 'package:daypay/resources/firestore_database_methods.dart';
 import 'package:daypay/test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -20,7 +21,6 @@ class InputPay extends HookConsumerWidget {
     // TextFieldで入力された値が格納されるContoller
     final TextEditingController _payContentController = TextEditingController();
     final TextEditingController _payAmountController = TextEditingController();
-    final valueController = TextEditingController();
 
     void setValue() {
       print('pass');
@@ -38,6 +38,27 @@ class InputPay extends HookConsumerWidget {
           },
         ),
       );
+    }
+
+    void setPay() async {
+      // ボタン押下不可に変更
+
+      // 登録処理
+      String res = await FirestoreDatabaseMethods().setPay(
+        content: _payContentController.text,
+        amount: _payAmountController.text,
+      );
+
+      print('res');
+      print(res);
+
+      // ボタン押下可能に変更
+
+      // 成功だった場合の処理
+      // 失敗だった場合の処理
+      // if (res != 'success') {
+      //   showSnackBar(res, context);
+      // }
     }
 
     return Scaffold(
@@ -105,7 +126,7 @@ class InputPay extends HookConsumerWidget {
               ),
             ),
             InkWell(
-              onTap: () => setValue(),
+              onTap: setPay,
               child: Container(
                 width: 100,
                 height: 100,
@@ -114,8 +135,12 @@ class InputPay extends HookConsumerWidget {
                   color: Color.fromARGB(255, 175, 231, 226),
                 ),
                 child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [Icon(Icons.currency_yen), Text('submit')]),
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.currency_yen),
+                    Text('submit'),
+                  ],
+                ),
               ),
             ),
           ],

--- a/lib/resources/firestore_database_methods.dart
+++ b/lib/resources/firestore_database_methods.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+
+class FirestoreDatabaseMethods {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // adding payinfo to Firebase Firestore Database
+  Future<String> setPay({
+    required String content,
+    required String amount,
+  }) async {
+    String res = 'Some error occured';
+    try {
+      await _firestore.collection('pay').doc().set({
+        'content': content,
+        'amount': amount,
+      });
+      res = 'Success!';
+    } catch (err) {
+      res = err.toString();
+    }
+    return res;
+  }
+}


### PR DESCRIPTION
■概要
- 変更内容を簡単に解説
  - textfieldに入力した値が登録ボタン押下によって、firebase firestoreに保存される

■変更のあったファイル、変更内容
- どのファイルで変更があったか
  - ADD: lib/input_pay.dart
    - firestoreへの引渡しメソッド（setPayメソッド）の追加
  - ADD: lib/resources/firestore_database_methods.dart
    - firebase firestoreへの登録処理
- ロジックがある場合、簡単な解説
  - 非同期通信でfirestoreへの登録処理を行う。firestoreのcollectionはpayに分類される。

■今回対応できなかったこと、気になること
- 今回対応しなかった内容
  - バリデーション処理

■確認方法、確認内容
- 行ったチェック内容などを記載
  - 正しい値を入力した状態で登録ボタンを押下&入力した値がfirestoreに正しく格納されていることを確認

■その他
- 気になることなど
  - 現状特になし。