### PR TITLE
[ADD]payカラムにuserId(uid)追加

### DIFF
--- a/lib/input_pay.dart
+++ b/lib/input_pay.dart
@@ -12,6 +12,7 @@ import 'package:state_notifier/state_notifier.dart';
 // TextFieldで入力された値を格納するProvider変数
 StateProvider<String> _payContentProvider = StateProvider((ref) => "");
 StateProvider<String> _payAmountProvider = StateProvider((ref) => "0");
+final _uidProvider = StateProvider<String>((ref) => "uidValue");
 
 class InputPay extends HookConsumerWidget {
   const InputPay({Key? key}) : super(key: key);
@@ -21,24 +22,25 @@ class InputPay extends HookConsumerWidget {
     // TextFieldで入力された値が格納されるContoller
     final TextEditingController _payContentController = TextEditingController();
     final TextEditingController _payAmountController = TextEditingController();
+    // final uidState = useProvider(_uidProvider).state;
 
-    void setValue() {
-      print('pass');
-      ref.read(_payContentProvider.state).state = _payContentController.text;
-      ref.read(_payAmountProvider.state).state = _payAmountController.text;
-      print(ref.read(_payContentProvider.state).state);
-      print(ref.read(_payAmountProvider.state).state);
-      // validation処理
-      // DB保存処理
-      // 別ページ遷移処理
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (context) {
-            return CheckMonthlyUsing();
-          },
-        ),
-      );
-    }
+    // void setValue() {
+    //   print('pass');
+    //   ref.read(_payContentProvider.state).state = _payContentController.text;
+    //   ref.read(_payAmountProvider.state).state = _payAmountController.text;
+    //   print(ref.read(_payContentProvider.state).state);
+    //   print(ref.read(_payAmountProvider.state).state);
+    //   // validation処理
+    //   // DB保存処理
+    //   // 別ページ遷移処理
+    //   Navigator.of(context).push(
+    //     MaterialPageRoute(
+    //       builder: (context) {
+    //         return CheckMonthlyUsing();
+    //       },
+    //     ),
+    //   );
+    // }
 
     void setPay() async {
       // ボタン押下不可に変更
@@ -47,6 +49,7 @@ class InputPay extends HookConsumerWidget {
       String res = await FirestoreDatabaseMethods().setPay(
         content: _payContentController.text,
         amount: _payAmountController.text,
+        uid: ref.watch(_uidProvider),
       );
 
       print('res');
@@ -142,6 +145,15 @@ class InputPay extends HookConsumerWidget {
                   ],
                 ),
               ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+            Column(
+              children: [
+                Text('本日使用した金額'),
+                Text('5000円'),
+              ],
             ),
           ],
         ),

--- a/lib/resources/firestore_database_methods.dart
+++ b/lib/resources/firestore_database_methods.dart
@@ -12,12 +12,14 @@ class FirestoreDatabaseMethods {
   Future<String> setPay({
     required String content,
     required String amount,
+    required String uid,
   }) async {
     String res = 'Some error occured';
     try {
       await _firestore.collection('pay').doc().set({
         'content': content,
         'amount': amount,
+        'uid': uid,
       });
       res = 'Success!';
     } catch (err) {


### PR DESCRIPTION
■概要
- 変更内容を簡単に解説
  - payのカラム属性にuid（user id）を追加。
    - これがないと単純に誰の支払い内容か分からなくなるため。

■変更のあったファイル、変更内容
- どのファイルで変更があったか
  - ADD: lib/input_pay.dart
  - ADD: lib/resources/firestore_database_methods.dart

■今回対応できなかったこと、気になること
- 今回対応しなかった内容
  - あくまで今回はサンプル的な感じで記載したのみで、本物のuidを取得してそれを渡しているわけではない。

■確認方法、確認内容
- 行ったチェック内容などを記載
  - 正しい値を入力した状態で登録ボタンを押下&入力した値がfirestoreに正しく格納されていることを確認

■その他
- 気になることなど
  - 現状特になし。